### PR TITLE
Merge of latest testing changes

### DIFF
--- a/colors/jummidark.vim
+++ b/colors/jummidark.vim
@@ -129,10 +129,10 @@ hi! IncSearch    ctermfg=NONE ctermbg=237 cterm=bold guifg=NONE guibg=#3a3a3a gu
 hi! SpecialComment ctermfg=242 ctermbg=235 cterm=NONE guifg=#6c6c6c guibg=#262626 gui=NONE
 
 "  Diff
-hi! DiffAdd      ctermfg=044 ctermbg=235 cterm=NONE guifg=#00d7d7 guibg=#262626 gui=NONE
-hi! DiffText     ctermfg=220 ctermbg=236 cterm=NONE guifg=#ffd700 guibg=#303030 gui=NONE
-hi! DiffChange   ctermfg=NONE ctermbg=237 cterm=NONE guifg=NONE guibg=#383838 gui=NONE
-hi! DiffDelete   ctermfg=161 ctermbg=235 cterm=NONE guifg=#d7005f guibg=#262626 gui=NONE
+hi! DiffAdd      ctermfg=049 ctermbg=NONE cterm=NONE guifg=#00ffaf guibg=NONE gui=NONE
+hi! DiffText     ctermfg=220 ctermbg=NONE cterm=NONE guifg=#ffd700 guibg=NONE gui=NONE
+hi! DiffChange   ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
+hi! DiffDelete   ctermfg=161 ctermbg=NONE cterm=NONE guifg=#d7005f guibg=NONE gui=NONE
 
 "  Line
 hi! StatusLine   ctermfg=232 ctermbg=136 cterm=bold guifg=#080808 guibg=#af8700 gui=bold
@@ -142,11 +142,12 @@ hi! LineNr       ctermfg=245 ctermbg=NONE cterm=NONE guifg=#8a8a8a guibg=NONE gu
 hi! ColorLineNr  ctermfg=15 ctermbg=NONE cterm=bold guifg=#FFFFFF guibg=NONE gui=bold
 hi! CursorLine   ctermfg=NONE ctermbg=16 cterm=NONE guifg=NONE guibg=#000000 gui=NONE
 hi! CursorLineNr ctermfg=136 ctermbg=16 cterm=bold guifg=#af8700 guibg=#000000 gui=bold
-hi! CursorColumn ctermfg=254 ctermbg=237 cterm=NONE guifg=#e4e4e4 guibg=#383838 gui=NONE
+hi! CursorLineSign ctermfg=NONE ctermbg=16 cterm=bold guifg=NONE guibg=#000000 gui=bold
+hi! CursorColumn ctermfg=NONE ctermbg=16 cterm=NONE guifg=NONE guibg=#000000 gui=NONE
+hi! SignColumn   ctermfg=NONE ctermbg=NONE cterm=NONE guifg=NONE guibg=NONE gui=NONE
 
 "  Select
 hi! Visual       ctermfg=NONE ctermbg=232 cterm=NONE guifg=NONE guibg=#080808 gui=NONE
-hi! SignColumn   ctermfg=15 ctermbg=237 cterm=NONE guifg=#FFFFFF guibg=#383838 gui=NONE
 hi! SpecialKey   ctermfg=15 ctermbg=237 cterm=NONE guifg=#FFFFFF guibg=#383838 gui=NONE
 hi! Cursor       ctermfg=232 ctermbg=136 cterm=NONE guifg=#080808 guibg=#af8700 gui=NONE
 hi! lCursor      ctermfg=232 ctermbg=NONE cterm=NONE guifg=#080808 guibg=NONE gui=NONE
@@ -164,6 +165,7 @@ hi! Folded       ctermfg=240 ctermbg=236 cterm=NONE guifg=#6c6c6c guibg=#303030 
 hi! FoldColumn   ctermfg=147 ctermbg=237 cterm=NONE guifg=#afafff guibg=#383838 gui=NONE
 hi! ColorColumn  ctermfg=NONE ctermbg=236 cterm=NONE guifg=NONE guibg=#303030 gui=NONE
 hi! VertSplit    ctermfg=236 ctermbg=236 cterm=NONE guifg=#303030 guibg=#303030 gui=NONE
+hi! CusrsorLineFold ctermfg=NONE ctermbg=236 cterm=NONE guifg=NONE guibg=#303030 gui=NONE
 
 "  Tab
 hi! Title        ctermfg=15 ctermbg=NONE cterm=bold guifg=#FFFFFF guibg=NONE gui=bold

--- a/colors/jummidark.vim
+++ b/colors/jummidark.vim
@@ -118,8 +118,10 @@ hi! Todo         ctermfg=161 ctermbg=NONE cterm=NONE guifg=#d7005f guibg=NONE gu
 
 " Special Highlight Assignments {{{
 " Error/Warning
+hi! Error     ctermfg=000 ctermbg=168 cterm=NONE guifg=#000000 guibg=#d75f87 gui=NONE
 hi! ErrorMsg     ctermfg=000 ctermbg=168 cterm=NONE guifg=#000000 guibg=#d75f87 gui=NONE
 hi! WarningMsg   ctermfg=000 ctermbg=049 cterm=NONE guifg=#000000 guibg=#00ffaf gui=NONE
+hi! NvimInternalError     ctermfg=000 ctermbg=168 cterm=NONE guifg=#000000 guibg=#d75f87 gui=NONE
 
 " Search Highlight
 hi! Search       ctermfg=NONE ctermbg=237 cterm=bold guifg=NONE guibg=#3a3a3a gui=bold
@@ -176,6 +178,8 @@ hi! TabLineSel   ctermfg=254 ctermbg=235 cterm=bold guifg=#e4e4e4 guibg=#262626 
 "  Menu
 hi! PmenuSel     ctermfg=135 ctermbg=234 cterm=bold guifg=#af5fff guibg=#1c1c1c gui=bold
 hi! Pmenu        ctermfg=249 ctermbg=236 cterm=NONE guifg=#b2b2b2 guibg=#303030 gui=NONE
+hi! PmenuThumb   ctermfg=Black ctermbg=254 cterm=NONE guifg=Black guibg=#e4e4e4 gui=NONE
+
 
 "  Link
 hi! link gitcommitSummary String
@@ -209,5 +213,12 @@ hi! jsxString    ctermfg=147 ctermbg=NONE cterm=NONE guifg=#afafff guibg=NONE gu
 "   setlocal winhighlight=Normal:ActiveWindow,NormalNC:InactiveWindow
 " endfunction
 "  }}}
+
+" CoC Highlight Groups
+hi! CocExplorerErrorColor_Internal ctermfg=254 ctermbg=234 cterm=NONE guifg=#e4e4e4 guibg=#1c1c1c gui=NONE 
+
+" Miscellaneous Problem colors
+hi! RedrawDebugClear ctermfg=Black ctermbg=Yellow cterm=NONE guifg=Black guibg=Yellow gui=NONE 
+
 
 " ex: set foldmethod=marker:

--- a/colors/jummidark.vim
+++ b/colors/jummidark.vim
@@ -25,6 +25,7 @@ let g:colors_name = "jummidark"
 "|  235 | #262626   | lowGray2     | foreground   ||  235 | #262626   | lowGray2     | background
 "|  234 | #1c1c1c   | lowGray3     |              ||  234 | #1c1c1c   | lowGray3     | 0 black
 "|  232 | #080808   | Background   |              ||  232 | #080808   | Background   |
+"|   16 | #000000   | black        |              ||   16 | #000000   | black        | 0 black
 "|  135 | #af5fff   | middlePurple |              ||  141 | #af87ff   | middlePurple | 9 Blue, 5 DarkMagenta, 13 Magenta 
 "|   93 | #8700ff   | lowPurple    |              ||  135 | #af5fff   | lowPurple    | 1 DarkBlue
 "|   44 | #00d7d7   | highGreen    |              ||  049 | #00ffaf   | highGreen    | 6 Brown, 14 Yellow
@@ -50,7 +51,7 @@ let g:colors_name = "jummidark"
 "
 
 " Normal text and Vim background Assignment
-hi! Normal       ctermfg=254 ctermbg=235 cterm=NONE guifg=#e4e4e4 guibg=#262626 gui=NONE
+hi! Normal       ctermfg=254 ctermbg=234 cterm=NONE guifg=#e4e4e4 guibg=#1c1c1c gui=NONE
 
 " Named Color Assignments {{{
 "
@@ -139,8 +140,8 @@ hi! StatusLineNC ctermfg=232 ctermbg=242 cterm=NONE guifg=#080808 guibg=#6c6c6c 
 hi! MsgArea      ctermfg=NONE ctermbg=236 cterm=NONE guifg=NONE guibg=#303030 gui=NONE
 hi! LineNr       ctermfg=245 ctermbg=NONE cterm=NONE guifg=#8a8a8a guibg=NONE gui=NONE
 hi! ColorLineNr  ctermfg=15 ctermbg=NONE cterm=bold guifg=#FFFFFF guibg=NONE gui=bold
-hi! CursorLine   ctermfg=NONE ctermbg=234 cterm=NONE guifg=NONE guibg=#1c1c1c gui=NONE
-hi! CursorLineNr ctermfg=136 ctermbg=234 cterm=bold guifg=#af8700 guibg=#1c1c1c gui=bold
+hi! CursorLine   ctermfg=NONE ctermbg=16 cterm=NONE guifg=NONE guibg=#000000 gui=NONE
+hi! CursorLineNr ctermfg=136 ctermbg=16 cterm=bold guifg=#af8700 guibg=#000000 gui=bold
 hi! CursorColumn ctermfg=254 ctermbg=237 cterm=NONE guifg=#e4e4e4 guibg=#383838 gui=NONE
 
 "  Select


### PR DESCRIPTION
- unified the signcolumn and numbercolumn bg color with the rest of the theme. previously these colors were arbitrarily set and had not kept up with the various background color changes. the overall effect of this is that vim's panes feel more open and terminal-like or emacs-like, rather than feeling barricaded on the edges like a composited vscode window
- fixed various problem highlight groups that occasionally appear in nvim messages and menus